### PR TITLE
chore: illustrate logging

### DIFF
--- a/examples/basic.exs
+++ b/examples/basic.exs
@@ -55,11 +55,8 @@ config = %Momento.Configuration{}
 cache_client = %Momento.CacheClient{config: config}
 
 1..20
-  |> Enum.map(&Momento.Examples.Basic.generate_key(&1))
-  |> Enum.map(&Momento.Examples.Basic.issue_set(cache_client, &1))
-  |> Enum.map(&Momento.Examples.Basic.await_set(&1))
-  |> Enum.map(&Momento.Examples.Basic.issue_get(cache_client, &1))
-  |> Enum.map(&Momento.Examples.Basic.await_get(&1))
-
-
-
+|> Enum.map(&Momento.Examples.Basic.generate_key(&1))
+|> Enum.map(&Momento.Examples.Basic.issue_set(cache_client, &1))
+|> Enum.map(&Momento.Examples.Basic.await_set(&1))
+|> Enum.map(&Momento.Examples.Basic.issue_get(cache_client, &1))
+|> Enum.map(&Momento.Examples.Basic.await_get(&1))

--- a/examples/config/config.exs
+++ b/examples/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :logger, :console,
+       format: "[$level] $message $metadata\n",
+       metadata: [:error_code, :mfa]

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -1,4 +1,6 @@
 defmodule Momento.CacheClient do
+  require Logger
+
   @moduledoc """
   Documentation for `Momento.CacheClient`.
   """
@@ -20,7 +22,7 @@ defmodule Momento.CacheClient do
   def set(cache_client, cache_name, key, value, ttl_seconds) do
     time_to_sleep = :rand.uniform(100)
     :timer.sleep(time_to_sleep)
-    IO.puts("Completed 'set' for key #{key}")
+    Logger.info("Completed 'set' for key #{key}")
     rand = :rand.uniform(2)
 
     case rand do
@@ -41,7 +43,7 @@ defmodule Momento.CacheClient do
   def get(cache_client, cache_name, key) do
     time_to_sleep = :rand.uniform(100)
     :timer.sleep(time_to_sleep)
-    IO.puts("Completed 'get' for key #{key}")
+    Logger.info("Completed 'get' for key #{key}")
     rand = :rand.uniform(3)
 
     case rand do


### PR DESCRIPTION
This commit shows how to configure and consume the logging library.
This was a prereq to building the config object, so that we could
see whether or not we need to provide a logging compatibility layer.
(I now believe that we do not.)
