### PR TITLE
feat: add transport strategy / grpc config to configuration

### DIFF
--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -1,5 +1,6 @@
 defmodule Momento.CacheClient do
   require Logger
+  alias Momento.Config.Configuration, as: Configuration
 
   @moduledoc """
   Documentation for `Momento.CacheClient`.
@@ -7,7 +8,7 @@ defmodule Momento.CacheClient do
   @enforce_keys [:config]
   defstruct [:config]
 
-  @opaque t() :: %{required(:config) => Momento.Configuration.t()}
+  @opaque t() :: %{required(:config) => Configuration.t()}
 
   @doc """
   Set the value in cache with a given time to live (TTL) seconds.

--- a/src/lib/momento/config.ex
+++ b/src/lib/momento/config.ex
@@ -1,8 +1,0 @@
-defmodule Momento.Configuration do
-  @moduledoc """
-  Documentation for `Momento.Configuration`.
-  """
-  defstruct []
-
-  @opaque t() :: %{}
-end

--- a/src/lib/momento/config/configuration.ex
+++ b/src/lib/momento/config/configuration.ex
@@ -1,0 +1,19 @@
+defmodule Momento.Config.Configuration do
+  @moduledoc """
+  Configuration for Momento CacheClient
+  """
+  @enforce_keys[:transport_strategy]
+  defstruct [:transport_strategy]
+
+  @opaque t() :: %__MODULE__{
+            transport_strategy: Momento.Config.Transport.TransportStrategy.t()
+          }
+
+  @spec with_transport_strategy(
+          config :: Momento.Config.Configuration.t(),
+          transport_strategy :: Momento.Config.Transport.TransportStrategy.t()
+        ) :: Momento.Config.Configuration.t()
+  def with_transport_strategy(config, transport_strategy) do
+    %{config | transport_strategy: transport_strategy}
+  end
+end

--- a/src/lib/momento/config/transport/grpc_configuration.ex
+++ b/src/lib/momento/config/transport/grpc_configuration.ex
@@ -1,0 +1,11 @@
+defmodule Momento.Config.Transport.GrpcConfiguration do
+  @moduledoc """
+  Encapsulates gRPC configuration tunables.
+  """
+  @enforce_keys [:deadline_millis]
+  defstruct [:deadline_millis]
+
+  @opaque t() :: %__MODULE__{
+            deadline_millis: number()
+          }
+end

--- a/src/lib/momento/config/transport/transport_strategy.ex
+++ b/src/lib/momento/config/transport/transport_strategy.ex
@@ -1,0 +1,27 @@
+defmodule Momento.Config.Transport.TransportStrategy do
+  alias Momento.Config.Transport.TransportStrategy, as: TransportStrategy
+  alias Momento.Config.Transport.GrpcConfiguration, as: GrpcConfiguration
+
+  @moduledoc """
+  Configuration for the low-level Momento transport layer
+  """
+  @enforce_keys [:grpc_config]
+  defstruct [:grpc_config]
+
+  @opaque t() :: %__MODULE__{
+            grpc_config: GrpcConfiguration.t()
+          }
+
+  @doc """
+  Copy constructor for overriding the gRPC configuration
+  """
+  @spec with_grpc_config(
+          transport_strategy :: TransportStrategy.t(),
+          grpc_config :: GrpcConfiguration.t()
+        ) :: TransportStrategy.t()
+  def with_grpc_config(transport_strategy, grpc_config) do
+    %TransportStrategy{
+      grpc_config: grpc_config
+    }
+  end
+end

--- a/src/test/momento/config/configuration_test.exs
+++ b/src/test/momento/config/configuration_test.exs
@@ -1,0 +1,40 @@
+defmodule Momento.Config.ConfigurationTest do
+  alias Momento.Config.Transport.TransportStrategy, as: TransportStrategy
+  alias Momento.Config.Transport.GrpcConfiguration, as: GrpcConfiguration
+
+  use ExUnit.Case
+  doctest Momento.Config.Configuration
+
+  @test_grpc_configuration %GrpcConfiguration{
+    deadline_millis: 90210
+  }
+
+  @test_transport_strategy %TransportStrategy{
+    grpc_config: @test_grpc_configuration
+  }
+
+  @test_configuration %Momento.Config.Configuration{
+    transport_strategy: @test_transport_strategy
+  }
+
+  describe "Constructing Configuration" do
+    test "overriding transport strategy" do
+      new_grpc_configuration = %GrpcConfiguration{
+        deadline_millis: 424_242
+      }
+
+      new_transport_strategy = %TransportStrategy{
+        grpc_config: new_grpc_configuration
+      }
+
+      new_config =
+        Momento.Config.Configuration.with_transport_strategy(
+          @test_configuration,
+          new_transport_strategy
+        )
+
+      assert new_config.transport_strategy == new_transport_strategy
+      assert new_config.transport_strategy.grpc_config == new_grpc_configuration
+    end
+  end
+end

--- a/src/test/test_helper.exs
+++ b/src/test/test_helper.exs
@@ -1,0 +1,3 @@
+# test/test_helper.exs
+
+ExUnit.start()


### PR DESCRIPTION
This commit attempts to bulid out the first few bits of the configuration API. It creates a module for transport strategy and grpc config, and adds them to the configuration struct.