### PR TITLE
fix: validate server ssl certificates

### DIFF
--- a/examples/grpctest.exs
+++ b/examples/grpctest.exs
@@ -5,9 +5,11 @@ metadata = %{cache: "cache", Authorization: credential_provider.auth_token}
 
 IO.inspect(credential_provider.cache_endpoint)
 
+options = :tls_certificate_check.options(credential_provider.cache_endpoint)
+
 {:ok, channel} =
   GRPC.Stub.connect(credential_provider.cache_endpoint <> ":443",
-    cred: GRPC.Credential.new([])
+    cred: GRPC.Credential.new(ssl: options)
   )
 
 IO.puts("Setting key 'key' in cache 'cache'")

--- a/examples/mix.exs
+++ b/examples/mix.exs
@@ -21,7 +21,8 @@ defmodule Examples.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:momento, path: "../src"}
+      {:momento, path: "../src"},
+      {:tls_certificate_check, "~> 1.19"}
     ]
   end
 end

--- a/examples/mix.lock
+++ b/examples/mix.lock
@@ -11,4 +11,6 @@
   "jose": {:hex, :jose, "1.11.5", "3bc2d75ffa5e2c941ca93e5696b54978323191988eb8d225c2e663ddfefd515e", [:mix, :rebar3], [], "hexpm", "dcd3b215bafe02ea7c5b23dafd3eb8062a5cd8f2d904fd9caa323d37034ab384"},
   "protobuf": {:hex, :protobuf, "0.12.0", "58c0dfea5f929b96b5aa54ec02b7130688f09d2de5ddc521d696eec2a015b223", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "75fa6cbf262062073dd51be44dd0ab940500e18386a6c4e87d5819a58964dc45"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "tls_certificate_check": {:hex, :tls_certificate_check, "1.19.0", "c76c4c5d79ee79a2b11c84f910c825d6f024a78427c854f515748e9bd025e987", [:rebar3], [{:ssl_verify_fun, "~> 1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm", "4083b4a298add534c96125337cb01161c358bb32dd870d5a893aae685fd91d70"},
 }


### PR DESCRIPTION
This commit pulls in a library that bundles a CA cert chain
and provides TLS options that are compatible with the grpc
library. This allows us to enable full TLS cert verification
and gets rid of the warning we were previously seeing on
connections.
