### PR TITLE
feat: standardize the response types

### DIFF
--- a/examples/basic.exs
+++ b/examples/basic.exs
@@ -21,7 +21,7 @@ defmodule Momento.Examples.Basic do
     response = Task.await(set_task)
 
     case response do
-      :success -> Logger.info("'set' successful for key #{key}")
+      {:ok, _} -> Logger.info("'set' successful for key #{key}")
       {:error, error} -> Logger.info("Got an error for key #{key}: #{inspect(error)}")
     end
 
@@ -39,9 +39,14 @@ defmodule Momento.Examples.Basic do
     response = Task.await(get_task)
 
     case response do
-      {:hit, value} -> Logger.info("'get' resulted in a 'hit' for key #{key}: #{inspect(value)}")
-      :miss -> Logger.info("'get' resulted in a 'miss' for key #{key}.")
-      {:error, error} -> Logger.info("Got an error for key #{key}: #{inspect(error)}")
+      {:hit, result} ->
+        Logger.info("'get' resulted in a 'hit' for key #{key}: #{inspect(result.value)}")
+
+      :miss ->
+        Logger.info("'get' resulted in a 'miss' for key #{key}.")
+
+      {:error, error} ->
+        Logger.info("Got an error for key #{key}: #{inspect(error)}")
     end
 
     key

--- a/src/integration-test/momento/cache_client_test.exs
+++ b/src/integration-test/momento/cache_client_test.exs
@@ -33,14 +33,14 @@ defmodule CacheClientTest do
     value = "test_value"
     ttl_seconds = 60.0
 
-    assert CacheClient.set(cache_client, cache_name, key, value, ttl_seconds) == :success
+    {:ok, _} = CacheClient.set(cache_client, cache_name, key, value, ttl_seconds)
 
     {:hit, get_result} = CacheClient.get(cache_client, cache_name, key)
-    assert match?(^value, get_result)
+    assert match?(^value, get_result.value)
 
-    assert CacheClient.delete(cache_client, cache_name, key) == :success
+    {:ok, _} = CacheClient.delete(cache_client, cache_name, key)
 
-    assert CacheClient.get(cache_client, cache_name, key) == :miss
+    :miss = CacheClient.get(cache_client, cache_name, key)
   end
 
   test "set/5 returns an error with a bad key", %{
@@ -117,7 +117,7 @@ defmodule CacheClientTest do
   } do
     key = random_string(16)
 
-    assert CacheClient.delete(cache_client, cache_name, key) == :success
+    {:ok, _} = CacheClient.delete(cache_client, cache_name, key)
   end
 
   test "delete/3 validates cache name", %{cache_client: cache_client} do

--- a/src/integration-test/momento/cache_control_plane_test.exs
+++ b/src/integration-test/momento/cache_control_plane_test.exs
@@ -20,15 +20,15 @@ defmodule CacheControlPlaneTest do
     test "should be able to create a cache, list it, and delete it", %{cache_client: cache_client} do
       cache_name = "elixir-int-test-#{random_string(10)}"
 
-      {:success, result} = CacheClient.list_caches(cache_client)
+      {:ok, result} = CacheClient.list_caches(cache_client)
       cache_names = Enum.map(result.caches, fn c -> c.name end)
       assert(not Enum.member?(cache_names, cache_name))
-      :success = CacheClient.create_cache(cache_client, cache_name)
-      {:success, result} = CacheClient.list_caches(cache_client)
+      {:ok, _} = CacheClient.create_cache(cache_client, cache_name)
+      {:ok, result} = CacheClient.list_caches(cache_client)
       cache_names = Enum.map(result.caches, fn c -> c.name end)
       assert(Enum.member?(cache_names, cache_name))
-      :success = CacheClient.delete_cache(cache_client, cache_name)
-      {:success, result} = CacheClient.list_caches(cache_client)
+      {:ok, _} = CacheClient.delete_cache(cache_client, cache_name)
+      {:ok, result} = CacheClient.list_caches(cache_client)
       cache_names = Enum.map(result.caches, fn c -> c.name end)
       assert(not Enum.member?(cache_names, cache_name))
     end
@@ -45,9 +45,9 @@ defmodule CacheControlPlaneTest do
       cache_client: cache_client
     } do
       cache_name = "elixir-int-test-#{random_string(10)}"
-      :success = CacheClient.create_cache(cache_client, cache_name)
+      {:ok, _} = CacheClient.create_cache(cache_client, cache_name)
       :already_exists = CacheClient.create_cache(cache_client, cache_name)
-      :success = CacheClient.delete_cache(cache_client, cache_name)
+      {:ok, _} = CacheClient.delete_cache(cache_client, cache_name)
     end
   end
 
@@ -65,25 +65,3 @@ defmodule CacheControlPlaneTest do
     end
   end
 end
-
-#
-#    it('should return NotFoundError if deleting a non-existent cache', async () => {
-#      const cacheName = testCacheName();
-#      const deleteResponse = await Momento.deleteCache(cacheName);
-#      expectWithMessage(() => {
-#        expect(deleteResponse).toBeInstanceOf(DeleteCache.Error);
-#      }, `expected ERROR but got ${deleteResponse.toString()}`);
-#      if (deleteResponse instanceof DeleteCache.Error) {
-#        expect(deleteResponse.errorCode()).toEqual(
-#          MomentoErrorCode.NOT_FOUND_ERROR
-#        );
-#      }
-#    });
-#
-#    it('should return AlreadyExists response if trying to create a cache that already exists', async () => {
-#      const cacheName = testCacheName();
-#      await WithCache(Momento, cacheName, async () => {
-#        const createResponse = await Momento.createCache(cacheName);
-#        expect(createResponse).toBeInstanceOf(CreateCache.AlreadyExists);
-#      });
-#    });

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -67,7 +67,7 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `:success` on a successful create.
+  - `{:ok, %Momento.Responses.ListCaches.Ok{caches: caches}}` on a successful listing.
   - `{:error, error}` tuple if an error occurs.
   """
   @spec list_caches(client :: t()) :: Momento.Responses.ListCaches.t()
@@ -85,7 +85,7 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `:success` on a successful create.
+  - `{:ok, %Momento.Responses.CreateCache.Ok{}}` on a successful create.
   - `:already_exists` if a cache with the specified name already exists.
   - `{:error, error}` tuple if an error occurs.
   """
@@ -107,7 +107,7 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `:success` on a successful delete.
+  - `{:ok, %Momento.Responses.DeleteCache.Ok{}}` on a successful delete.
   - `{:error, error}` tuple if an error occurs.
   """
   @spec delete_cache(
@@ -131,7 +131,7 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `:success` on a successful set.
+  - `{:ok, %Momento.Responses.Set.Ok{}}` on a successful set.
   - `{:error, error}` tuple if an error occurs.
   """
   @spec set(
@@ -157,7 +157,7 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `{:hit, value}` tuple if the key exists.
+  - `{:ok, %Momento.Responses.Get.Hit{value: value}}` tuple if the key exists.
   - `:miss` if the key does not exist.
   - `{:error, error}` tuple if an error occurs.
   """
@@ -178,11 +178,11 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
-  - `:success` on a successful deletion.
+  - `{:ok, %Momento.Responses.Delete.Ok{}}` on a successful deletion.
   - `{:error, error}` tuple if an error occurs.
   """
   @spec delete(client :: t(), cache_name :: String.t(), key :: binary) ::
-          Momento.Responses.Get.t()
+          Momento.Responses.Delete.t()
   def delete(client, cache_name, key) do
     ScsDataClient.delete(client.data_client, cache_name, key)
   end

--- a/src/lib/momento/internal/scs_control_client.ex
+++ b/src/lib/momento/internal/scs_control_client.ex
@@ -2,8 +2,7 @@ defmodule Momento.Internal.ScsControlClient do
   import Momento.Validation
 
   alias Momento.Auth.CredentialProvider
-  alias Momento.Configuration
-  alias Momento.Responses.CacheInfo
+  alias Momento.Responses.{CacheInfo, CreateCache, DeleteCache, ListCaches}
 
   @enforce_keys [:auth_token, :channel]
   defstruct [:auth_token, :channel]
@@ -40,8 +39,8 @@ defmodule Momento.Internal.ScsControlClient do
            metadata: metadata
          ) do
       {:ok, response} ->
-        {:success,
-         %Momento.Responses.ListCaches.Success{
+        {:ok,
+         %ListCaches.Ok{
            caches: Enum.map(response.cache, fn c -> %CacheInfo{name: c.cache_name} end)
          }}
 
@@ -65,7 +64,7 @@ defmodule Momento.Internal.ScsControlClient do
              metadata: metadata
            ) do
         {:ok, _} ->
-          :success
+          {:ok, %CreateCache.Ok{}}
 
         {:error, error_response} ->
           err = Momento.Error.convert(error_response)
@@ -93,7 +92,7 @@ defmodule Momento.Internal.ScsControlClient do
              metadata: metadata
            ) do
         {:ok, _} ->
-          :success
+          {:ok, %DeleteCache.Ok{}}
 
         {:error, error_response} ->
           {:error, Momento.Error.convert(error_response)}

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -1,6 +1,6 @@
 defmodule Momento.Internal.ScsDataClient do
-  alias Momento.Configuration
   alias Momento.Auth.CredentialProvider
+  alias Momento.Responses.{Set, Get, Delete}
   import Momento.Validation
 
   @enforce_keys [:auth_token, :channel]
@@ -51,7 +51,7 @@ defmodule Momento.Internal.ScsDataClient do
       case Momento.Protos.CacheClient.Scs.Stub.set(data_client.channel, set_request,
              metadata: metadata
            ) do
-        {:ok, _} -> :success
+        {:ok, _} -> {:ok, %Set.Ok{}}
         {:error, error_response} -> {:error, Momento.Error.convert(error_response)}
       end
     else
@@ -72,7 +72,7 @@ defmodule Momento.Internal.ScsDataClient do
              metadata: metadata
            ) do
         {:ok, %Momento.Protos.CacheClient.GetResponse{result: :Hit, cache_body: cache_body}} ->
-          {:hit, cache_body}
+          {:hit, %Get.Hit{value: cache_body}}
 
         {:ok, %Momento.Protos.CacheClient.GetResponse{result: :Miss}} ->
           :miss
@@ -97,7 +97,7 @@ defmodule Momento.Internal.ScsDataClient do
       case Momento.Protos.CacheClient.Scs.Stub.delete(data_client.channel, delete_request,
              metadata: metadata
            ) do
-        {:ok, _} -> :success
+        {:ok, _} -> {:ok, %Delete.Ok{}}
         {:error, error_response} -> {:error, Momento.Error.convert(error_response)}
       end
     else

--- a/src/lib/momento/responses/create_cache.ex
+++ b/src/lib/momento/responses/create_cache.ex
@@ -1,3 +1,12 @@
 defmodule Momento.Responses.CreateCache do
-  @type t() :: :success | :already_exists | {:error, Momento.Error.t()}
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() ::
+          {:ok, Momento.Responses.CreateCache.Ok.t()}
+          | :already_exists
+          | {:error, Momento.Error.t()}
 end

--- a/src/lib/momento/responses/delete.ex
+++ b/src/lib/momento/responses/delete.ex
@@ -1,3 +1,9 @@
 defmodule Momento.Responses.Delete do
-  @type t() :: :success | {:error, Momento.Error.t()}
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() :: {:ok, Momento.Responses.Delete.Ok.t()} | {:error, Momento.Error.t()}
 end

--- a/src/lib/momento/responses/delete_cache.ex
+++ b/src/lib/momento/responses/delete_cache.ex
@@ -1,3 +1,9 @@
 defmodule Momento.Responses.DeleteCache do
-  @type t() :: :success | {:error, Momento.Error.t()}
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() :: {:ok, Momento.Responses.DeleteCache.Ok.t()} | {:error, Momento.Error.t()}
 end

--- a/src/lib/momento/responses/get.ex
+++ b/src/lib/momento/responses/get.ex
@@ -1,3 +1,12 @@
 defmodule Momento.Responses.Get do
-  @type t() :: {:hit, binary} | :miss | {:error, Momento.Error.t()}
+  defmodule Hit do
+    @enforce_keys [:value]
+    defstruct [:value]
+
+    @type t() :: %__MODULE__{
+            value: binary
+          }
+  end
+
+  @type t() :: {:hit, Momento.Responses.Get.Hit.t()} | :miss | {:error, Momento.Error.t()}
 end

--- a/src/lib/momento/responses/list_caches.ex
+++ b/src/lib/momento/responses/list_caches.ex
@@ -1,5 +1,5 @@
 defmodule Momento.Responses.ListCaches do
-  defmodule Success do
+  defmodule Ok do
     @enforce_keys [:caches]
     defstruct [:caches]
 
@@ -8,5 +8,5 @@ defmodule Momento.Responses.ListCaches do
           }
   end
 
-  @type t() :: {:success, Success.t()} | {:error, Momento.Error.t()}
+  @type t() :: {:ok, Ok.t()} | {:error, Momento.Error.t()}
 end

--- a/src/lib/momento/responses/set.ex
+++ b/src/lib/momento/responses/set.ex
@@ -1,3 +1,9 @@
 defmodule Momento.Responses.Set do
-  @type t() :: :success | {:error, Momento.Error.t()}
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() :: {:ok, Momento.Responses.Set.Ok.t()} | {:error, Momento.Error.t()}
 end


### PR DESCRIPTION
Change all methods that return 'success' to instead return the more idiomatic 'ok'.

Change all methods that return an atom when they succeed to return a struct as well, so we can add fields in the future without breaking customer code.

Change get to return a struct containing the value instead of the bare value.