### PR TITLE
feat: add sorted set put and fetch by rank functions

### DIFF
--- a/src/integration-test/momento/cache_client_test.exs
+++ b/src/integration-test/momento/cache_client_test.exs
@@ -79,10 +79,10 @@ defmodule CacheClientTest do
     value = "test_value"
 
     {:error, error} = CacheClient.set(cache_client, cache_name, key, value, "sixty")
-    assert String.contains?(error.message, "The TTL must be a positive float")
+    assert String.contains?(error.message, "The TTL must be a float")
 
     {:error, error} = CacheClient.set(cache_client, cache_name, key, value, -20.0)
-    assert String.contains?(error.message, "The TTL must be a positive float")
+    assert String.contains?(error.message, "The TTL must be positive")
   end
 
   test "get/3 returns miss when no value is found for a key", %{
@@ -135,5 +135,172 @@ defmodule CacheClientTest do
 
     {:error, error} = CacheClient.delete(cache_client, cache_name, 12345)
     assert String.contains?(error.message, "The key must be a binary")
+  end
+
+  describe "sorted_set_put_elements/5 happy path" do
+    test "should be able to put elements in a sorted set, overwriting existing elements", %{
+      cache_client: cache_client,
+      cache_name: cache_name
+    } do
+      sorted_set_name = random_string(16)
+      first_elements = %{"key1" => 1.0, "key2" => 2.0}
+      second_elements = %{"key2" => 5.0, "key3" => 3.0}
+
+      :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_elements(
+          cache_client,
+          cache_name,
+          sorted_set_name,
+          first_elements
+        )
+
+      {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+      assert hit.scored_values == [{"key1", 1.0}, {"key2", 2.0}]
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_elements(
+          cache_client,
+          cache_name,
+          sorted_set_name,
+          second_elements
+        )
+
+      {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+      assert hit.scored_values == [{"key1", 1.0}, {"key3", 3.0}, {"key2", 5.0}]
+    end
+  end
+
+  describe "sorted_set_put_element/6 happy path" do
+    test "should be able to put individual elements in a sorted set, overwriting existing elements",
+         %{
+           cache_client: cache_client,
+           cache_name: cache_name
+         } do
+      sorted_set_name = random_string(16)
+
+      :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_element(cache_client, cache_name, sorted_set_name, "key1", 1.0)
+
+      {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+      assert hit.scored_values == [{"key1", 1.0}]
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_element(cache_client, cache_name, sorted_set_name, "key1", 5.0)
+
+      {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+      assert hit.scored_values == [{"key1", 5.0}]
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_element(cache_client, cache_name, sorted_set_name, "key2", 2.0)
+
+      {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+      assert hit.scored_values == [{"key2", 2.0}, {"key1", 5.0}]
+    end
+  end
+
+  describe "sorted_set_fetch_by_rank/6" do
+    test "should be able to fetch in ascending and descending order", %{
+      cache_client: cache_client,
+      cache_name: cache_name
+    } do
+      sorted_set_name = random_string(16)
+      elements = %{"key1" => 1.0, "key2" => 2.0, "key3" => 3.0}
+
+      :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_elements(cache_client, cache_name, sorted_set_name, elements)
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(
+          cache_client,
+          cache_name,
+          sorted_set_name,
+          nil,
+          nil,
+          :asc
+        )
+
+      assert hit.scored_values == [{"key1", 1.0}, {"key2", 2.0}, {"key3", 3.0}]
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(
+          cache_client,
+          cache_name,
+          sorted_set_name,
+          nil,
+          nil,
+          :desc
+        )
+
+      assert hit.scored_values == [{"key3", 3.0}, {"key2", 2.0}, {"key1", 1.0}]
+    end
+
+    test "should be able to fetch a subset of a sorted set", %{
+      cache_client: cache_client,
+      cache_name: cache_name
+    } do
+      sorted_set_name = random_string(16)
+      elements = [{"key1", 1.0}, {"key2", 2.0}, {"key3", 3.0}, {"key4", 4.0}, {"key5", 5.0}]
+
+      :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
+
+      {:ok, _} =
+        CacheClient.sorted_set_put_elements(cache_client, cache_name, sorted_set_name, elements)
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name, 0, nil)
+
+      assert hit.scored_values == [
+               {"key1", 1.0},
+               {"key2", 2.0},
+               {"key3", 3.0},
+               {"key4", 4.0},
+               {"key5", 5.0}
+             ]
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name, 0, 5)
+
+      assert hit.scored_values == [
+               {"key1", 1.0},
+               {"key2", 2.0},
+               {"key3", 3.0},
+               {"key4", 4.0},
+               {"key5", 5.0}
+             ]
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name, 0, 100)
+
+      assert hit.scored_values == [
+               {"key1", 1.0},
+               {"key2", 2.0},
+               {"key3", 3.0},
+               {"key4", 4.0},
+               {"key5", 5.0}
+             ]
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name, 1, 3)
+
+      assert hit.scored_values == [{"key2", 2.0}, {"key3", 3.0}]
+
+      {:ok, hit} =
+        CacheClient.sorted_set_fetch_by_rank(
+          cache_client,
+          cache_name,
+          sorted_set_name,
+          1,
+          3,
+          :desc
+        )
+
+      assert hit.scored_values == [{"key4", 4.0}, {"key3", 3.0}]
+    end
   end
 end

--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -24,7 +24,7 @@ defmodule Momento.IntegrationTestUtils do
       }
     }
 
-    cache_client = CacheClient.create!(config, credential_provider)
+    cache_client = CacheClient.create!(config, credential_provider, 120.0)
     [cache_name: cache_name, cache_client: cache_client]
   end
 

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -199,7 +199,7 @@ defmodule Momento.CacheClient do
           sorted_set_name :: String.t(),
           value :: binary(),
           score :: float(),
-          collection_ttl :: CollectionTtl.t() | nil
+          opts :: [collection_ttl :: CollectionTtl.t()]
         ) :: SortedSet.PutElement.t()
   def sorted_set_put_element(
         client,
@@ -207,16 +207,17 @@ defmodule Momento.CacheClient do
         sorted_set_name,
         value,
         score,
-        collection_ttl \\ nil
+        opts \\ []
       ) do
-    ttl = collection_ttl || CollectionTtl.of(client.default_ttl_seconds)
+    collection_ttl =
+      Keyword.get(opts, :collection_ttl, CollectionTtl.of(client.default_ttl_seconds))
 
     case ScsDataClient.sorted_set_put_elements(
            client.data_client,
            cache_name,
            sorted_set_name,
            [{value, score}],
-           ttl
+           collection_ttl
          ) do
       {:ok, _} -> {:ok, %Momento.Responses.SortedSet.PutElement.Ok{}}
       {:error, error} -> {:error, error}
@@ -228,23 +229,24 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
           elements :: %{binary() => float()} | [{binary(), float()}],
-          collection_ttl :: CollectionTtl.t() | nil
+          opts :: [collection_ttl :: CollectionTtl.t()]
         ) :: SortedSet.PutElements.t()
   def sorted_set_put_elements(
         client,
         cache_name,
         sorted_set_name,
         elements,
-        collection_ttl \\ nil
+        opts \\ []
       ) do
-    ttl = collection_ttl || CollectionTtl.of(client.default_ttl_seconds)
+    collection_ttl =
+      Keyword.get(opts, :collection_ttl, CollectionTtl.of(client.default_ttl_seconds))
 
     ScsDataClient.sorted_set_put_elements(
       client.data_client,
       cache_name,
       sorted_set_name,
       elements,
-      ttl
+      collection_ttl
     )
   end
 
@@ -252,18 +254,18 @@ defmodule Momento.CacheClient do
           client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          start_rank :: integer() | nil,
-          end_rank :: integer() | nil,
-          sort_order :: :asc | :desc
+          opts :: [start_rank: integer(), end_rank: integer(), sort_order: :asc | :desc]
         ) :: SortedSet.Fetch.t()
   def sorted_set_fetch_by_rank(
         client,
         cache_name,
         sorted_set_name,
-        start_rank \\ nil,
-        end_rank \\ nil,
-        sort_order \\ :asc
+        opts \\ []
       ) do
+    start_rank = Keyword.get(opts, :start_rank)
+    end_rank = Keyword.get(opts, :end_rank)
+    sort_order = Keyword.get(opts, :sort_order, :asc)
+
     ScsDataClient.sorted_set_fetch_by_rank(
       client.data_client,
       cache_name,

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -282,7 +282,7 @@ defmodule Momento.Internal.ScsDataClient do
                 {element.value, element.score}
               end)
 
-            {:ok, %Momento.Responses.SortedSet.Fetch.Hit{scored_values: scored_values}}
+            {:ok, %Momento.Responses.SortedSet.Fetch.Hit{value: scored_values}}
 
           {:missing, _} ->
             :miss

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -1,6 +1,7 @@
 defmodule Momento.Internal.ScsDataClient do
   alias Momento.Auth.CredentialProvider
   alias Momento.Responses.{Set, Get, Delete}
+  alias Momento.Requests.CollectionTtl
   import Momento.Validation
 
   @enforce_keys [:auth_token, :channel]
@@ -102,6 +103,193 @@ defmodule Momento.Internal.ScsDataClient do
       end
     else
       error -> error
+    end
+  end
+
+  @spec sorted_set_put_elements(
+          data_client :: t(),
+          cache_name :: String.t(),
+          sorted_set_name :: String.t(),
+          elements :: %{binary() => float()} | [{binary(), float()}],
+          collection_ttl :: CollectionTtl.t()
+        ) :: Momento.Responses.SortedSet.PutElements.t()
+  def sorted_set_put_elements(
+        data_client,
+        cache_name,
+        sorted_set_name,
+        elements,
+        collection_ttl
+      ) do
+    with :ok <- validate_cache_name(cache_name),
+         :ok <- validate_sorted_set_name(sorted_set_name),
+         :ok <- validate_sorted_set_elements(elements),
+         :ok <- validate_collection_ttl(collection_ttl) do
+      try do
+        send_sorted_set_put_elements(
+          data_client,
+          cache_name,
+          sorted_set_name,
+          elements,
+          collection_ttl
+        )
+      rescue
+        e -> {:error, Momento.Error.convert(e)}
+      end
+    else
+      error -> error
+    end
+  end
+
+  @spec send_sorted_set_put_elements(
+          data_client :: t(),
+          cache_name :: String.t(),
+          sorted_set_name :: String.t(),
+          elements :: %{binary() => float()} | [{binary(), float()}],
+          collection_ttl :: CollectionTtl.t()
+        ) :: Momento.Responses.SortedSet.PutElements.t()
+  defp send_sorted_set_put_elements(
+         data_client,
+         cache_name,
+         sorted_set_name,
+         elements,
+         collection_ttl
+       ) do
+    ttl_milliseconds = collection_ttl.ttl_seconds |> Kernel.*(1000) |> round()
+    metadata = %{cache: cache_name, Authorization: data_client.auth_token}
+
+    transformed_elements =
+      Enum.map(elements, fn {value, score} ->
+        %Momento.Protos.CacheClient.SortedSetElement{
+          value: value,
+          score: score
+        }
+      end)
+
+    sorted_set_put_request = %Momento.Protos.CacheClient.SortedSetPutRequest{
+      set_name: sorted_set_name,
+      elements: transformed_elements,
+      ttl_milliseconds: ttl_milliseconds,
+      refresh_ttl: collection_ttl.refresh_ttl
+    }
+
+    case Momento.Protos.CacheClient.Scs.Stub.sorted_set_put(
+           data_client.channel,
+           sorted_set_put_request,
+           metadata: metadata
+         ) do
+      {:ok, _} -> {:ok, %Momento.Responses.SortedSet.PutElements.Ok{}}
+      {:error, error_response} -> {:error, Momento.Error.convert(error_response)}
+    end
+  end
+
+  @spec sorted_set_fetch_by_rank(
+          data_client :: t(),
+          cache_name :: String.t(),
+          sorted_set_name :: String.t(),
+          start_rank :: integer() | nil,
+          end_rank :: integer() | nil,
+          sort_order :: :asc | :desc
+        ) :: Momento.Responses.SortedSet.Fetch.t()
+  def sorted_set_fetch_by_rank(
+        data_client,
+        cache_name,
+        sorted_set_name,
+        start_rank \\ nil,
+        end_rank \\ nil,
+        sort_order \\ :asc
+      ) do
+    with :ok <- validate_cache_name(cache_name),
+         :ok <- validate_sorted_set_name(sorted_set_name),
+         :ok <- validate_index_range(start_rank, end_rank),
+         :ok <- validate_sort_order(sort_order) do
+      try do
+        send_sorted_set_fetch_by_rank(
+          data_client,
+          cache_name,
+          sorted_set_name,
+          start_rank,
+          end_rank,
+          sort_order
+        )
+      rescue
+        e -> {:error, Momento.Error.convert(e)}
+      end
+    else
+      error -> error
+    end
+  end
+
+  @spec send_sorted_set_fetch_by_rank(
+          data_client :: t(),
+          cache_name :: String.t(),
+          sorted_set_name :: String.t(),
+          start_rank :: integer() | nil,
+          end_rank :: integer() | nil,
+          sort_order :: :asc | :desc
+        ) :: Momento.Responses.SortedSet.Fetch.t()
+  defp send_sorted_set_fetch_by_rank(
+         data_client,
+         cache_name,
+         sorted_set_name,
+         start_rank,
+         end_rank,
+         sort_order
+       ) do
+    metadata = %{cache: cache_name, Authorization: data_client.auth_token}
+
+    start_index =
+      case start_rank do
+        nil -> {:unbounded_start, %Momento.Protos.CacheClient.Unbounded{}}
+        _ -> {:inclusive_start_index, start_rank}
+      end
+
+    end_index =
+      case end_rank do
+        nil -> {:unbounded_end, %Momento.Protos.CacheClient.Unbounded{}}
+        _ -> {:exclusive_end_index, end_rank}
+      end
+
+    order =
+      case sort_order do
+        :asc -> 0
+        _ -> 1
+      end
+
+    fetch_request = %Momento.Protos.CacheClient.SortedSetFetchRequest{
+      set_name: sorted_set_name,
+      order: order,
+      with_scores: true,
+      range:
+        {:by_index,
+         %Momento.Protos.CacheClient.SortedSetFetchRequest.ByIndex{
+           start: start_index,
+           end: end_index
+         }}
+    }
+
+    case Momento.Protos.CacheClient.Scs.Stub.sorted_set_fetch(
+           data_client.channel,
+           fetch_request,
+           metadata: metadata
+         ) do
+      {:ok, response} ->
+        case response.sorted_set do
+          {:found, found} ->
+            {:values_with_scores, values_with_scores} = found.elements
+
+            scored_values =
+              Enum.map(values_with_scores.elements, fn element ->
+                {element.value, element.score}
+              end)
+
+            {:ok, %Momento.Responses.SortedSet.Fetch.Hit{scored_values: scored_values}}
+
+          {:missing, _} ->
+            :miss
+        end
+
+      {:error, error_response} ->
+        {:error, Momento.Error.convert(error_response)}
     end
   end
 end

--- a/src/lib/momento/requests/collection_ttl.ex
+++ b/src/lib/momento/requests/collection_ttl.ex
@@ -1,0 +1,17 @@
+defmodule Momento.Requests.CollectionTtl do
+  @enforce_keys [:ttl_seconds, :refresh_ttl]
+  defstruct [:ttl_seconds, :refresh_ttl]
+
+  @type t() :: %__MODULE__{
+          ttl_seconds: float() | nil,
+          refresh_ttl: boolean()
+        }
+
+  @spec of(ttl_seconds :: float()) :: t()
+  def of(ttl_seconds) do
+    %Momento.Requests.CollectionTtl{
+      ttl_seconds: ttl_seconds,
+      refresh_ttl: true
+    }
+  end
+end

--- a/src/lib/momento/responses/sorted_set/fetch.ex
+++ b/src/lib/momento/responses/sorted_set/fetch.ex
@@ -1,0 +1,13 @@
+defmodule Momento.Responses.SortedSet.Fetch do
+  defmodule Hit do
+    @enforce_keys [:scored_values]
+    defstruct [:scored_values]
+
+    @type t() :: %__MODULE__{
+            scored_values: [{binary(), float()}]
+          }
+  end
+
+  @type t() ::
+          {:ok, Momento.Responses.SortedSet.Fetch.Hit.t()} | :miss | {:error, Momento.Error.t()}
+end

--- a/src/lib/momento/responses/sorted_set/fetch.ex
+++ b/src/lib/momento/responses/sorted_set/fetch.ex
@@ -1,10 +1,10 @@
 defmodule Momento.Responses.SortedSet.Fetch do
   defmodule Hit do
-    @enforce_keys [:scored_values]
-    defstruct [:scored_values]
+    @enforce_keys [:value]
+    defstruct [:value]
 
     @type t() :: %__MODULE__{
-            scored_values: [{binary(), float()}]
+            value: [{binary(), float()}]
           }
   end
 

--- a/src/lib/momento/responses/sorted_set/put_element.ex
+++ b/src/lib/momento/responses/sorted_set/put_element.ex
@@ -1,0 +1,9 @@
+defmodule Momento.Responses.SortedSet.PutElement do
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() :: {:ok, Momento.Responses.SortedSet.PutElement.Ok.t()} | {:error, Momento.Error.t()}
+end

--- a/src/lib/momento/responses/sorted_set/put_elements.ex
+++ b/src/lib/momento/responses/sorted_set/put_elements.ex
@@ -1,0 +1,9 @@
+defmodule Momento.Responses.SortedSet.PutElements do
+  defmodule Ok do
+    @enforce_keys []
+    defstruct []
+    @type t() :: %__MODULE__{}
+  end
+
+  @type t() :: {:ok, Momento.Responses.SortedSet.PutElements.Ok.t()} | {:error, Momento.Error.t()}
+end

--- a/src/lib/momento/validation.ex
+++ b/src/lib/momento/validation.ex
@@ -1,27 +1,156 @@
 defmodule Momento.Validation do
   import Momento.Error
 
-  @spec validate_cache_name(String.t()) :: :ok | {:error, Momento.Error.t()}
-  def validate_cache_name(nil), do: {:error, invalid_argument("The cache name cannot be nil")}
-
+  @spec validate_cache_name(cache_name :: String.t()) :: :ok | {:error, Momento.Error.t()}
   def validate_cache_name(cache_name) do
-    if String.valid?(cache_name),
-      do: :ok,
-      else: {:error, invalid_argument("The cache name must be a string")}
+    validate_string(cache_name, "cache name")
   end
 
-  @spec validate_key(binary()) :: :ok | {:error, Momento.Error.t()}
-  def validate_key(nil), do: {:error, invalid_argument("The key cannot be nil")}
-  def validate_key(key) when is_binary(key), do: :ok
-  def validate_key(_), do: {:error, invalid_argument("The key must be a binary")}
+  @spec validate_sorted_set_name(sorted_set_name :: String.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  def validate_sorted_set_name(sorted_set_name) do
+    validate_string(sorted_set_name, "sorted set name")
+  end
 
-  @spec validate_value(binary()) :: :ok | {:error, Momento.Error.t()}
-  def validate_value(nil), do: {:error, invalid_argument("The value cannot be nil")}
-  def validate_value(value) when is_binary(value), do: :ok
-  def validate_value(_), do: {:error, invalid_argument("The value must be a binary")}
+  @spec validate_sorted_set_elements(elements :: %{binary() => float()} | [{binary(), float()}]) ::
+          :ok | {:error, Momento.Error.t()}
+  def validate_sorted_set_elements(nil),
+    do: {:error, invalid_argument("Sorted set elements cannot be nil")}
 
-  @spec validate_ttl(float()) :: :ok | {:error, Momento.Error.t()}
-  def validate_ttl(nil), do: {:error, invalid_argument("The TTL cannot be nil")}
-  def validate_ttl(ttl) when is_float(ttl) and ttl > 0.0, do: :ok
-  def validate_ttl(_), do: {:error, invalid_argument("The TTL must be a positive float")}
+  def validate_sorted_set_elements(elements) do
+    try do
+      case Enum.all?(elements, fn {value, score} ->
+             is_binary(value) and is_float(score)
+           end) do
+        true ->
+          :ok
+
+        false ->
+          {:error,
+           invalid_argument(
+             "Sorted set elements must contain only binary values and float scores"
+           )}
+      end
+    rescue
+      e ->
+        {:error,
+         invalid_argument(
+           "Sorted set elements must be a map or list of tuples of values and scores",
+           e
+         )}
+    end
+  end
+
+  @spec validate_sort_order(sort_order :: atom()) :: :ok | {:error, Momento.Error.t()}
+  def validate_sort_order(sort_order) when sort_order in [:asc, :desc], do: :ok
+
+  def validate_sort_order(_),
+    do: {:error, invalid_argument("The sort order must be either :asc or :desc")}
+
+  @spec validate_key(key :: binary()) :: :ok | {:error, Momento.Error.t()}
+  def validate_key(key), do: validate_binary(key, "key")
+
+  @spec validate_value(value :: binary()) :: :ok | {:error, Momento.Error.t()}
+  def validate_value(value), do: validate_binary(value, "value")
+
+  @spec validate_score(score :: float()) :: :ok | {:error, Momento.Error.t()}
+  def validate_score(score), do: validate_float(score, "score")
+
+  @spec validate_ttl(ttl :: float()) :: :ok | {:error, Momento.Error.t()}
+  def validate_ttl(ttl), do: validate_positive_float(ttl, "TTL")
+
+  @spec validate_collection_ttl(collection_ttl :: Momento.Requests.CollectionTtl.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  def validate_collection_ttl(collection_ttl) do
+    with :ok <-
+           validate_struct(
+             collection_ttl,
+             "collection_ttl",
+             Elixir.Momento.Requests.CollectionTtl
+           ),
+         :ok <- validate_positive_float(collection_ttl.ttl_seconds, "TTL") do
+      :ok
+    else
+      error -> error
+    end
+  end
+
+  @spec validate_index_range(start_index :: integer() | nil, end_index :: integer() | nil) ::
+          :ok | {:error, Momento.Error.t()}
+  def validate_index_range(nil, _), do: :ok
+  def validate_index_range(_, nil), do: :ok
+
+  def validate_index_range(start_index, _) when not is_integer(start_index),
+    do: {:error, invalid_argument("#{start_index} is not an integer")}
+
+  def validate_index_range(_, end_index) when not is_integer(end_index),
+    do: {:error, invalid_argument("#{end_index} is not an integer")}
+
+  def validate_index_range(start_index, end_index) when start_index < end_index, do: :ok
+
+  def validate_index_range(_, _),
+    do:
+      {:error,
+       invalid_argument("start_index (inclusive) must be less than end_index (exclusive)")}
+
+  @spec validate_not_nil(any(), String.t()) :: :ok | {:error, Momento.Error.t()}
+  def validate_not_nil(nil, name), do: {:error, invalid_argument("#{name} cannot be nil")}
+  def validate_not_nil(_, _), do: :ok
+
+  @spec validate_string(string :: String.t(), name_type :: String.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  defp validate_string(nil, string_name),
+    do: {:error, invalid_argument("The #{string_name} cannot be nil")}
+
+  defp validate_string(string, string_name) do
+    if String.valid?(string),
+      do: :ok,
+      else: {:error, invalid_argument("The #{string_name} must be a string")}
+  end
+
+  @spec validate_binary(binary :: binary(), binary_name :: String.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  defp validate_binary(nil, binary_name),
+    do: {:error, invalid_argument("The #{binary_name} cannot be nil")}
+
+  defp validate_binary(binary, _) when is_binary(binary), do: :ok
+
+  defp validate_binary(_, binary_name),
+    do: {:error, invalid_argument("The #{binary_name} must be a binary")}
+
+  @spec validate_positive_float(float :: float(), float_name :: String.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  defp validate_positive_float(float, float_name) do
+    case validate_float(float, float_name) do
+      :ok ->
+        if float > 0.0 do
+          :ok
+        else
+          {:error, invalid_argument("The #{float_name} must be positive")}
+        end
+
+      error ->
+        error
+    end
+  end
+
+  @spec validate_float(float :: float(), float_name :: String.t()) ::
+          :ok | {:error, Momento.Error.t()}
+  defp validate_float(nil, float_name),
+    do: {:error, invalid_argument("The #{float_name} cannot be nil")}
+
+  defp validate_float(float, _) when is_float(float), do: :ok
+
+  defp validate_float(_, float_name),
+    do: {:error, invalid_argument("The #{float_name} must be a float")}
+
+  @spec validate_struct(struct :: struct(), struct_name :: String.t(), struct_type :: atom()) ::
+          :ok | {:error, Momento.Error.t()}
+  defp validate_struct(nil, struct_name, _),
+    do: {:error, invalid_argument("The #{struct_name} cannot be nil")}
+
+  defp validate_struct(struct, _, struct_type) when struct.__struct__ == struct_type, do: :ok
+
+  defp validate_struct(_, struct_name, struct_type),
+    do: {:error, invalid_argument("#{struct_name} must be an #{Atom.to_string(struct_type)}")}
 end

--- a/src/test/momento/cache_client_test.exs
+++ b/src/test/momento/cache_client_test.exs
@@ -1,0 +1,465 @@
+defmodule Momento.CacheClientTest do
+  use ExUnit.Case
+
+  alias Momento.CacheClient
+
+  @fake_cache_client %Momento.CacheClient{
+    config: %Momento.Config.Configuration{
+      transport_strategy: %Momento.Config.Transport.TransportStrategy{
+        grpc_config: %Momento.Config.Transport.GrpcConfiguration{
+          deadline_millis: 5000
+        }
+      }
+    },
+    credential_provider: %Momento.Auth.CredentialProvider{
+      control_endpoint: "fake",
+      cache_endpoint: "fake",
+      auth_token: "fake"
+    },
+    default_ttl_seconds: 100.0,
+    control_client: "fake",
+    data_client: "fake"
+  }
+
+  describe "sorted_set_put_element/6" do
+    test "returns an error with a bad cache name" do
+      sorted_set_name = "sorted set name"
+      value = "value"
+      score = 1.0
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          nil,
+          sorted_set_name,
+          value,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The cache name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          12345,
+          sorted_set_name,
+          value,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The cache name must be a string")
+    end
+
+    test "returns an error with a bad sorted set name" do
+      cache_name = "cache name"
+      value = "value"
+      score = 1.0
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          nil,
+          value,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The sorted set name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          12345,
+          value,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The sorted set name must be a string")
+    end
+
+    test "returns an error with a bad value" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      score = 1.0
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          nil,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          12345,
+          score,
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+    end
+
+    test "returns an error with a bad score" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      value = "value"
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          value,
+          nil,
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          value,
+          "one",
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+    end
+
+    test "returns an error with a bad collection ttl" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      value = "value"
+      score = 1.0
+
+      {:error, error} =
+        CacheClient.sorted_set_put_element(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          value,
+          score,
+          "ttl"
+        )
+
+      assert String.contains?(
+               error.message,
+               "collection_ttl must be an Elixir.Momento.Requests.CollectionTtl"
+             )
+    end
+  end
+
+  describe "sorted_set_put_elements/5" do
+    test "returns an error with a bad cache name" do
+      sorted_set_name = "sorted set name"
+      elements = [{"key1", 1.0}]
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          nil,
+          sorted_set_name,
+          elements,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The cache name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          12345,
+          sorted_set_name,
+          elements,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The cache name must be a string")
+    end
+
+    test "returns an error with a bad sorted set name" do
+      cache_name = "cache name"
+      elements = [{"key1", 1.0}]
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          nil,
+          elements,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The sorted set name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          12345,
+          elements,
+          collection_ttl
+        )
+
+      assert String.contains?(error.message, "The sorted set name must be a string")
+    end
+
+    test "returns an error with bad elements" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          nil,
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements cannot be nil"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          [{nil, 1.0}],
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          [{12345, 1.0}],
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          [{"key1", nil}],
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          [{"key1", "one"}],
+          collection_ttl
+        )
+
+      assert String.contains?(
+               error.message,
+               "Sorted set elements must contain only binary values and float scores"
+             )
+    end
+
+    test "returns an error with a bad collection ttl" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      elements = [{"key1", 1.0}]
+
+      {:error, error} =
+        CacheClient.sorted_set_put_elements(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          elements,
+          "ttl"
+        )
+
+      assert String.contains?(
+               error.message,
+               "collection_ttl must be an Elixir.Momento.Requests.CollectionTtl"
+             )
+    end
+  end
+
+  describe "sorted_set_fetch_by_rank/6" do
+    test "returns an error with a bad cache name" do
+      sorted_set_name = "sorted set name"
+      start_rank = 1
+      end_rank = 10
+      sort_order = :asc
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          nil,
+          sorted_set_name,
+          start_rank,
+          end_rank,
+          sort_order
+        )
+
+      assert String.contains?(error.message, "The cache name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          12345,
+          sorted_set_name,
+          start_rank,
+          end_rank,
+          sort_order
+        )
+
+      assert String.contains?(error.message, "The cache name must be a string")
+    end
+
+    test "returns an error with a bad sorted set name" do
+      cache_name = "cache name"
+      start_rank = 1
+      end_rank = 10
+      sort_order = :asc
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          nil,
+          start_rank,
+          end_rank,
+          sort_order
+        )
+
+      assert String.contains?(error.message, "The sorted set name cannot be nil")
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          12345,
+          start_rank,
+          end_rank,
+          sort_order
+        )
+
+      assert String.contains?(error.message, "The sorted set name must be a string")
+    end
+
+    test "returns an error with bad ranks" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      sort_order = :asc
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          "start",
+          10,
+          sort_order
+        )
+
+      assert String.contains?(error.message, "start is not an integer")
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          1,
+          "end",
+          sort_order
+        )
+
+      assert String.contains?(error.message, "end is not an integer")
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          100,
+          10,
+          sort_order
+        )
+
+      assert String.contains?(
+               error.message,
+               "start_index (inclusive) must be less than end_index (exclusive)"
+             )
+    end
+
+    test "returns an error with a sort order" do
+      cache_name = "cache name"
+      sorted_set_name = "sorted set name"
+      start_rank = 1
+      end_rank = 10
+
+      {:error, error} =
+        CacheClient.sorted_set_fetch_by_rank(
+          @fake_cache_client,
+          cache_name,
+          sorted_set_name,
+          start_rank,
+          end_rank,
+          :bad_order
+        )
+
+      assert String.contains?(error.message, "The sort order must be either :asc or :desc")
+    end
+  end
+end

--- a/src/test/momento/cache_client_test.exs
+++ b/src/test/momento/cache_client_test.exs
@@ -26,7 +26,7 @@ defmodule Momento.CacheClientTest do
       sorted_set_name = "sorted set name"
       value = "value"
       score = 1.0
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_element(
@@ -35,7 +35,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           value,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The cache name cannot be nil")
@@ -47,7 +47,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           value,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The cache name must be a string")
@@ -57,7 +57,7 @@ defmodule Momento.CacheClientTest do
       cache_name = "cache name"
       value = "value"
       score = 1.0
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_element(
@@ -66,7 +66,7 @@ defmodule Momento.CacheClientTest do
           nil,
           value,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The sorted set name cannot be nil")
@@ -78,7 +78,7 @@ defmodule Momento.CacheClientTest do
           12345,
           value,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The sorted set name must be a string")
@@ -88,7 +88,7 @@ defmodule Momento.CacheClientTest do
       cache_name = "cache name"
       sorted_set_name = "sorted set name"
       score = 1.0
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_element(
@@ -97,7 +97,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           nil,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -112,7 +112,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           12345,
           score,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -125,7 +125,7 @@ defmodule Momento.CacheClientTest do
       cache_name = "cache name"
       sorted_set_name = "sorted set name"
       value = "value"
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_element(
@@ -134,7 +134,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           value,
           nil,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -149,7 +149,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           value,
           "one",
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -171,7 +171,7 @@ defmodule Momento.CacheClientTest do
           sorted_set_name,
           value,
           score,
-          "ttl"
+          collection_ttl: "ttl"
         )
 
       assert String.contains?(
@@ -185,7 +185,7 @@ defmodule Momento.CacheClientTest do
     test "returns an error with a bad cache name" do
       sorted_set_name = "sorted set name"
       elements = [{"key1", 1.0}]
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_elements(
@@ -193,7 +193,7 @@ defmodule Momento.CacheClientTest do
           nil,
           sorted_set_name,
           elements,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The cache name cannot be nil")
@@ -204,7 +204,7 @@ defmodule Momento.CacheClientTest do
           12345,
           sorted_set_name,
           elements,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The cache name must be a string")
@@ -213,7 +213,7 @@ defmodule Momento.CacheClientTest do
     test "returns an error with a bad sorted set name" do
       cache_name = "cache name"
       elements = [{"key1", 1.0}]
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_elements(
@@ -221,7 +221,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           nil,
           elements,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The sorted set name cannot be nil")
@@ -232,7 +232,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           12345,
           elements,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(error.message, "The sorted set name must be a string")
@@ -241,7 +241,7 @@ defmodule Momento.CacheClientTest do
     test "returns an error with bad elements" do
       cache_name = "cache name"
       sorted_set_name = "sorted set name"
-      collection_ttl = Momento.Requests.CollectionTtl.of(60)
+      collection_ttl = Momento.Requests.CollectionTtl.of(60.0)
 
       {:error, error} =
         CacheClient.sorted_set_put_elements(
@@ -249,7 +249,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           nil,
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -263,7 +263,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           [{nil, 1.0}],
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -277,7 +277,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           [{12345, 1.0}],
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -291,7 +291,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           [{"key1", nil}],
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -305,7 +305,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           [{"key1", "one"}],
-          collection_ttl
+          collection_ttl: collection_ttl
         )
 
       assert String.contains?(
@@ -325,7 +325,7 @@ defmodule Momento.CacheClientTest do
           cache_name,
           sorted_set_name,
           elements,
-          "ttl"
+          collection_ttl: "ttl"
         )
 
       assert String.contains?(
@@ -347,9 +347,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           nil,
           sorted_set_name,
-          start_rank,
-          end_rank,
-          sort_order
+          start_rank: start_rank,
+          end_rank: end_rank,
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "The cache name cannot be nil")
@@ -359,9 +359,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           12345,
           sorted_set_name,
-          start_rank,
-          end_rank,
-          sort_order
+          start_rank: start_rank,
+          end_rank: end_rank,
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "The cache name must be a string")
@@ -378,9 +378,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           nil,
-          start_rank,
-          end_rank,
-          sort_order
+          start_rank: start_rank,
+          end_rank: end_rank,
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "The sorted set name cannot be nil")
@@ -390,9 +390,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           12345,
-          start_rank,
-          end_rank,
-          sort_order
+          start_rank: start_rank,
+          end_rank: end_rank,
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "The sorted set name must be a string")
@@ -408,9 +408,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           sorted_set_name,
-          "start",
-          10,
-          sort_order
+          start_rank: "start",
+          end_rank: 10,
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "start is not an integer")
@@ -420,9 +420,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           sorted_set_name,
-          1,
-          "end",
-          sort_order
+          start_rank: 1,
+          end_rank: "end",
+          sort_order: sort_order
         )
 
       assert String.contains?(error.message, "end is not an integer")
@@ -432,9 +432,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           sorted_set_name,
-          100,
-          10,
-          sort_order
+          start_rank: 100,
+          end_rank: 10,
+          sort_order: sort_order
         )
 
       assert String.contains?(
@@ -454,9 +454,9 @@ defmodule Momento.CacheClientTest do
           @fake_cache_client,
           cache_name,
           sorted_set_name,
-          start_rank,
-          end_rank,
-          :bad_order
+          start_rank: start_rank,
+          end_rank: end_rank,
+          sort_order: :bad_order
         )
 
       assert String.contains?(error.message, "The sort order must be either :asc or :desc")


### PR DESCRIPTION
Add sorted set put element and put elements methods.

Add sorted set fetch by rank.

Flesh out input validation.

Create unit test module for cache-client that handles input validation tests to avoid cluttering the integration tests.

Make the Momento.Error cause an exception instead of a string to better capture info from unexpected exceptions.