### PR TITLE
chore: redact auth token and response value changes

### DIFF
--- a/src/integration-test/momento/cache_client_test.exs
+++ b/src/integration-test/momento/cache_client_test.exs
@@ -1008,7 +1008,7 @@ defmodule CacheClientTest do
           "key99"
         ])
 
-      assert [{"key1", 1.0}, {"key99", nil}] = response.values
+      assert [{"key1", 1.0}, {"key99", nil}] = response.value
 
       {:ok, response} =
         CacheClient.sorted_set_get_scores(cache_client, cache_name, sorted_set_name, [
@@ -1016,7 +1016,7 @@ defmodule CacheClientTest do
           "key99"
         ])
 
-      assert [{"key98", nil}, {"key99", nil}] = response.values
+      assert [{"key98", nil}, {"key99", nil}] = response.value
     end
 
     test "should fail if the cache name is invalid", %{

--- a/src/lib/momento/internal/scs_control_client.ex
+++ b/src/lib/momento/internal/scs_control_client.ex
@@ -12,6 +12,12 @@ defmodule Momento.Internal.ScsControlClient do
             channel: GRPC.Channel.t()
           }
 
+  defimpl Inspect, for: Momento.Internal.ScsControlClient do
+    def inspect(%Momento.Internal.ScsControlClient{} = control_client, _opts) do
+      "#Momento.Internal.ScsControlClient<auth_token: [hidden], channel: #{inspect(control_client.channel)}>"
+    end
+  end
+
   @spec create!(CredentialProvider.t()) :: t()
   def create!(credential_provider) do
     control_endpoint = CredentialProvider.control_endpoint(credential_provider)

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -12,6 +12,12 @@ defmodule Momento.Internal.ScsDataClient do
             channel: GRPC.Channel.t()
           }
 
+  defimpl Inspect, for: Momento.Internal.ScsDataClient do
+    def inspect(%Momento.Internal.ScsDataClient{} = data_client, _opts) do
+      "#Momento.Internal.ScsDataClient<auth_token: [hidden], channel: #{inspect(data_client.channel)}>"
+    end
+  end
+
   @spec create!(CredentialProvider.t()) :: t()
   def create!(credential_provider) do
     cache_endpoint = CredentialProvider.cache_endpoint(credential_provider)
@@ -588,7 +594,7 @@ defmodule Momento.Internal.ScsDataClient do
              sorted_set_name,
              [value]
            ) do
-        {:ok, %Momento.Responses.SortedSet.GetScores.Hit{values: values}} ->
+        {:ok, %Momento.Responses.SortedSet.GetScores.Hit{value: values}} ->
           case values do
             [] ->
               :miss
@@ -662,7 +668,7 @@ defmodule Momento.Internal.ScsDataClient do
                     end
                   end)
 
-                {:ok, %Momento.Responses.SortedSet.GetScores.Hit{values: values_to_scores}}
+                {:ok, %Momento.Responses.SortedSet.GetScores.Hit{value: values_to_scores}}
 
               %Momento.Protos.CacheClient.SortedSetGetScoreResponse{
                 sorted_set:

--- a/src/lib/momento/responses/sorted_set/get_scores.ex
+++ b/src/lib/momento/responses/sorted_set/get_scores.ex
@@ -1,8 +1,8 @@
 defmodule Momento.Responses.SortedSet.GetScores do
   defmodule Hit do
-    @enforce_keys [:values]
-    defstruct [:values]
-    @type t() :: %__MODULE__{values: [{binary(), float() | nil}]}
+    @enforce_keys [:value]
+    defstruct [:value]
+    @type t() :: %__MODULE__{value: [{binary(), float() | nil}]}
   end
 
   @type t() ::


### PR DESCRIPTION
Redact the auth token in the inspect methods for scs_data_client and scs_control_client.

Change the get-scores hit response containing the values from 'values' to 'value'.