### PR TITLE
chore: make set ttl optional and misc fixes

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -10,8 +10,7 @@ jobs:
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-#      TEST_CACHE_NAME: elixir-integration-test-ci-${{ github.sha }}
-      TEST_CACHE_NAME: elixir-integration-test-ci
+      TEST_CACHE_NAME: elixir-integration-test-ci-${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v3

--- a/src/integration-test/momento/cache_control_plane_test.exs
+++ b/src/integration-test/momento/cache_control_plane_test.exs
@@ -8,12 +8,15 @@ defmodule CacheControlPlaneTest do
   import Momento.IntegrationTestUtils,
     only: [
       initialize_cache_client: 0,
+      cleanup_cache: 1,
       random_string: 1,
       assert_validates_cache_name: 1
     ]
 
   setup_all do
-    {:ok, initialize_cache_client()}
+    client_state = initialize_cache_client()
+    on_exit(fn -> cleanup_cache(client_state) end)
+    {:ok, client_state}
   end
 
   describe "create_cache, list_caches, delete_cache happy path" do

--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -25,7 +25,23 @@ defmodule Momento.IntegrationTestUtils do
     }
 
     cache_client = CacheClient.create!(config, credential_provider, 120.0)
+
+    case CacheClient.create_cache(cache_client, cache_name) do
+      {:ok, _} -> :ok
+      :already_exists -> :ok
+      {:error, error} -> raise error
+    end
+
     [cache_name: cache_name, cache_client: cache_client]
+  end
+
+  @spec cleanup_cache(cache_state :: [cache_name: String.t(), cache_client: CacheClient.t()]) ::
+          :ok
+  def cleanup_cache(cache_state) do
+    cache_name = Keyword.fetch!(cache_state, :cache_name)
+    cache_client = Keyword.fetch!(cache_state, :cache_client)
+    CacheClient.delete_cache(cache_client, cache_name)
+    :ok
   end
 
   def random_string(length) do

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -147,10 +147,10 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           key :: binary(),
           value :: binary(),
-          ttl_seconds :: float() | nil
+          opts :: [ttl_seconds :: float()]
         ) :: Set.t()
-  def set(client, cache_name, key, value, ttl_seconds) do
-    ttl = ttl_seconds || client.default_ttl_seconds
+  def set(client, cache_name, key, value, opts \\ []) do
+    ttl = Keyword.get(opts, :ttl_seconds, client.default_ttl_seconds)
     ScsDataClient.set(client.data_client, cache_name, key, value, ttl)
   end
 

--- a/src/lib/momento/config/configuration.ex
+++ b/src/lib/momento/config/configuration.ex
@@ -2,7 +2,7 @@ defmodule Momento.Config.Configuration do
   @moduledoc """
   Configuration for Momento CacheClient
   """
-  @enforce_keys[:transport_strategy]
+  @enforce_keys [:transport_strategy]
   defstruct [:transport_strategy]
 
   @opaque t() :: %__MODULE__{

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -558,6 +558,15 @@ defmodule Momento.Internal.ScsDataClient do
 
               %Momento.Protos.CacheClient.SortedSetGetRankResponse{
                 rank:
+                  {:element_rank,
+                   %Momento.Protos.CacheClient.SortedSetGetRankResponse.RankResponsePart{
+                     result: :Miss
+                   }}
+              } ->
+                :miss
+
+              %Momento.Protos.CacheClient.SortedSetGetRankResponse{
+                rank:
                   {:missing,
                    %Momento.Protos.CacheClient.SortedSetGetRankResponse.SortedSetMissing{}}
               } ->

--- a/src/lib/momento/validation.ex
+++ b/src/lib/momento/validation.ex
@@ -103,9 +103,12 @@ defmodule Momento.Validation do
     do: {:error, invalid_argument("The #{string_name} cannot be nil")}
 
   defp validate_string(string, string_name) do
-    if String.valid?(string),
-      do: :ok,
-      else: {:error, invalid_argument("The #{string_name} must be a string")}
+    with true <- is_binary(string),
+         String.valid?(string) do
+      :ok
+    else
+      _ -> {:error, invalid_argument("The #{string_name} must be a string")}
+    end
   end
 
   @spec validate_binary(binary :: binary(), binary_name :: String.t()) ::


### PR DESCRIPTION
Make CacheClient.set() ttl_seconds optional to match the other functions that take a ttl.

Fix a whitespace issue that was causing a warning on @enforce_keys in Configuration.

Make the integration tests create and delete the test cache.

Make the github action use a unique cache name for each test run.

Fix a validation error that occurs in elixir 1.15.

Add a missing case to get_rank in which the sorted set exists but the desired value does not.