### PR TITLE
feat: Add pre-built configurations

### DIFF
--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -2,9 +2,7 @@ defmodule Momento.IntegrationTestUtils do
   use ExUnit.Case
 
   alias Momento.CacheClient
-  alias Momento.Config.Transport.GrpcConfiguration
-  alias Momento.Config.Transport.TransportStrategy
-  alias Momento.Config.Configuration
+  alias Momento.Configurations
   alias Momento.Auth.CredentialProvider
 
   def initialize_cache_client() do
@@ -16,14 +14,7 @@ defmodule Momento.IntegrationTestUtils do
 
     credential_provider = CredentialProvider.from_env_var!("TEST_AUTH_TOKEN")
 
-    config = %Configuration{
-      transport_strategy: %TransportStrategy{
-        grpc_config: %GrpcConfiguration{
-          deadline_millis: 5000
-        }
-      }
-    }
-
+    config = Configurations.Laptop.latest()
     cache_client = CacheClient.create!(config, credential_provider, 120.0)
 
     case CacheClient.create_cache(cache_client, cache_name) do

--- a/src/lib/momento/config/configuration.ex
+++ b/src/lib/momento/config/configuration.ex
@@ -6,8 +6,8 @@ defmodule Momento.Config.Configuration do
   defstruct [:transport_strategy]
 
   @type t() :: %__MODULE__{
-            transport_strategy: Momento.Config.Transport.TransportStrategy.t()
-          }
+          transport_strategy: Momento.Config.Transport.TransportStrategy.t()
+        }
 
   @spec with_transport_strategy(
           config :: Momento.Config.Configuration.t(),

--- a/src/lib/momento/config/configuration.ex
+++ b/src/lib/momento/config/configuration.ex
@@ -5,7 +5,7 @@ defmodule Momento.Config.Configuration do
   @enforce_keys [:transport_strategy]
   defstruct [:transport_strategy]
 
-  @opaque t() :: %__MODULE__{
+  @type t() :: %__MODULE__{
             transport_strategy: Momento.Config.Transport.TransportStrategy.t()
           }
 

--- a/src/lib/momento/config/transport/transport_strategy.ex
+++ b/src/lib/momento/config/transport/transport_strategy.ex
@@ -20,8 +20,6 @@ defmodule Momento.Config.Transport.TransportStrategy do
           grpc_config :: GrpcConfiguration.t()
         ) :: TransportStrategy.t()
   def with_grpc_config(transport_strategy, grpc_config) do
-    %TransportStrategy{
-      grpc_config: grpc_config
-    }
+    %{transport_strategy | grpc_config: grpc_config}
   end
 end

--- a/src/lib/momento/configurations.ex
+++ b/src/lib/momento/configurations.ex
@@ -1,0 +1,29 @@
+defmodule Momento.Configurations do
+  defmodule Laptop do
+    @spec latest() :: Momento.Config.Configuration.t()
+    def latest() do
+      %Momento.Config.Configuration{
+        transport_strategy: %Momento.Config.Transport.TransportStrategy{
+          grpc_config: %Momento.Config.Transport.GrpcConfiguration{
+            deadline_millis: 5000
+          }
+        }
+      }
+    end
+  end
+
+  defmodule InRegion do
+    defmodule Default do
+      @spec latest() :: Momento.Config.Configuration.t()
+      def latest() do
+        %Momento.Config.Configuration{
+          transport_strategy: %Momento.Config.Transport.TransportStrategy{
+            grpc_config: %Momento.Config.Transport.GrpcConfiguration{
+              deadline_millis: 1100
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/src/test/momento/cache_client_test.exs
+++ b/src/test/momento/cache_client_test.exs
@@ -2,16 +2,12 @@ defmodule Momento.CacheClientTest do
   use ExUnit.Case
 
   alias Momento.CacheClient
+  alias Momento.Configurations
+  alias Momento.Auth.CredentialProvider
 
   @fake_cache_client %Momento.CacheClient{
-    config: %Momento.Config.Configuration{
-      transport_strategy: %Momento.Config.Transport.TransportStrategy{
-        grpc_config: %Momento.Config.Transport.GrpcConfiguration{
-          deadline_millis: 5000
-        }
-      }
-    },
-    credential_provider: %Momento.Auth.CredentialProvider{
+    config: Configurations.Laptop.latest(),
+    credential_provider: %CredentialProvider{
       control_endpoint: "fake",
       cache_endpoint: "fake",
       auth_token: "fake"


### PR DESCRIPTION
This commit adds pre-built configurations in Momento.Configurations;
this will prevent users from needing to construct the grpc / transport
strategy configs directly.
