### PR TITLE
feat: support numbers for ttls/scores

### DIFF
--- a/src/integration-test/momento/cache_client_test.exs
+++ b/src/integration-test/momento/cache_client_test.exs
@@ -80,7 +80,7 @@ defmodule CacheClientTest do
     value = "test_value"
 
     {:error, error} = CacheClient.set(cache_client, cache_name, key, value, ttl_seconds: "sixty")
-    assert String.contains?(error.message, "The TTL must be a float")
+    assert String.contains?(error.message, "The TTL must be a number")
 
     {:error, error} = CacheClient.set(cache_client, cache_name, key, value, ttl_seconds: -20.0)
     assert String.contains?(error.message, "The TTL must be positive")
@@ -190,7 +190,7 @@ defmodule CacheClientTest do
       assert hit.value == [{"key1", 1.0}]
 
       {:ok, _} =
-        CacheClient.sorted_set_put_element(cache_client, cache_name, sorted_set_name, "key1", 5.0)
+        CacheClient.sorted_set_put_element(cache_client, cache_name, sorted_set_name, "key1", 5)
 
       {:ok, hit} = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
       assert hit.value == [{"key1", 5.0}]
@@ -209,7 +209,7 @@ defmodule CacheClientTest do
       cache_name: cache_name
     } do
       sorted_set_name = random_string(16)
-      elements = %{"key1" => 1.0, "key2" => 2.0, "key3" => 3.0}
+      elements = %{"key1" => 1.0, "key2" => 2, "key3" => 3.0}
 
       :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
 
@@ -242,7 +242,7 @@ defmodule CacheClientTest do
       cache_name: cache_name
     } do
       sorted_set_name = random_string(16)
-      elements = [{"key1", 1.0}, {"key2", 2.0}, {"key3", 3.0}, {"key4", 4.0}, {"key5", 5.0}]
+      elements = [{"key1", 1.0}, {"key2", 2.0}, {"key3", 3.0}, {"key4", 4}, {"key5", 5.0}]
 
       :miss = CacheClient.sorted_set_fetch_by_rank(cache_client, cache_name, sorted_set_name)
 

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -31,7 +31,7 @@ defmodule Momento.CacheClient do
   @opaque t() :: %__MODULE__{
             config: Configuration.t(),
             credential_provider: CredentialProvider.t(),
-            default_ttl_seconds: float(),
+            default_ttl_seconds: number(),
             control_client: ScsControlClient.t(),
             data_client: ScsDataClient.t()
           }
@@ -51,7 +51,7 @@ defmodule Momento.CacheClient do
   @spec create!(
           config :: Configuration.t(),
           credential_provider :: CredentialProvider.t(),
-          default_ttl_seconds :: float()
+          default_ttl_seconds :: number()
         ) :: t()
   def create!(config, credential_provider, default_ttl_seconds) do
     with control_client <- ScsControlClient.create!(credential_provider),
@@ -147,7 +147,7 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           key :: binary(),
           value :: binary(),
-          opts :: [ttl_seconds :: float()]
+          opts :: [ttl_seconds :: number()]
         ) :: Set.t()
   def set(client, cache_name, key, value, opts \\ []) do
     ttl = Keyword.get(opts, :ttl_seconds, client.default_ttl_seconds)
@@ -198,7 +198,7 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
           value :: binary(),
-          score :: float(),
+          score :: number(),
           opts :: [collection_ttl :: CollectionTtl.t()]
         ) :: SortedSet.PutElement.t()
   def sorted_set_put_element(
@@ -228,7 +228,7 @@ defmodule Momento.CacheClient do
           client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          elements :: %{binary() => float()} | [{binary(), float()}],
+          elements :: %{binary() => number()} | [{binary(), number()}],
           opts :: [collection_ttl :: CollectionTtl.t()]
         ) :: SortedSet.PutElements.t()
   def sorted_set_put_elements(
@@ -281,8 +281,8 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
           opts :: [
-            min_score: float(),
-            max_score: float(),
+            min_score: number(),
+            max_score: number(),
             offset: integer(),
             count: integer(),
             sort_order: :asc | :desc
@@ -425,7 +425,7 @@ defmodule Momento.CacheClient do
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
           value :: binary(),
-          amount :: float(),
+          amount :: number(),
           opts :: [collection_ttl :: CollectionTtl.t()]
         ) :: Momento.Responses.SortedSet.IncrementScore.t()
   def sorted_set_increment_score(

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -39,7 +39,7 @@ defmodule Momento.Internal.ScsDataClient do
           cache_name :: String.t(),
           key :: binary(),
           value :: binary(),
-          ttl_seconds :: float()
+          ttl_seconds :: number()
         ) :: Momento.Responses.Set.t()
   def set(data_client, cache_name, key, value, ttl_seconds) do
     with :ok <- validate_cache_name(cache_name),
@@ -116,7 +116,7 @@ defmodule Momento.Internal.ScsDataClient do
           data_client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          elements :: %{binary() => float()} | [{binary(), float()}],
+          elements :: %{binary() => number()} | [{binary(), number()}],
           collection_ttl :: CollectionTtl.t()
         ) :: Momento.Responses.SortedSet.PutElements.t()
   def sorted_set_put_elements(
@@ -150,7 +150,7 @@ defmodule Momento.Internal.ScsDataClient do
           data_client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          elements :: %{binary() => float()} | [{binary(), float()}],
+          elements :: %{binary() => number()} | [{binary(), number()}],
           collection_ttl :: CollectionTtl.t()
         ) :: Momento.Responses.SortedSet.PutElements.t()
   defp send_sorted_set_put_elements(
@@ -303,8 +303,8 @@ defmodule Momento.Internal.ScsDataClient do
           data_client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          min_score :: float() | nil,
-          max_score :: float() | nil,
+          min_score :: number() | nil,
+          max_score :: number() | nil,
           offset :: integer() | nil,
           count :: integer() | nil,
           sort_order :: :asc | :desc
@@ -344,8 +344,8 @@ defmodule Momento.Internal.ScsDataClient do
           data_client :: t(),
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
-          min_score :: float() | nil,
-          max_score :: float() | nil,
+          min_score :: number() | nil,
+          max_score :: number() | nil,
           offset :: integer() | nil,
           count :: integer() | nil,
           sort_order :: :asc | :desc
@@ -703,7 +703,7 @@ defmodule Momento.Internal.ScsDataClient do
           cache_name :: String.t(),
           sorted_set_name :: String.t(),
           value :: binary(),
-          amount :: float(),
+          amount :: number(),
           collection_ttl :: CollectionTtl.t()
         ) :: Momento.Responses.SortedSet.IncrementScore.t()
   def sorted_set_increment_score(

--- a/src/lib/momento/requests/collection_ttl.ex
+++ b/src/lib/momento/requests/collection_ttl.ex
@@ -3,11 +3,11 @@ defmodule Momento.Requests.CollectionTtl do
   defstruct [:ttl_seconds, :refresh_ttl]
 
   @type t() :: %__MODULE__{
-          ttl_seconds: float() | nil,
+          ttl_seconds: number() | nil,
           refresh_ttl: boolean()
         }
 
-  @spec of(ttl_seconds :: float()) :: t()
+  @spec of(ttl_seconds :: number()) :: t()
   def of(ttl_seconds) do
     %Momento.Requests.CollectionTtl{
       ttl_seconds: ttl_seconds,

--- a/src/lib/momento/validation.ex
+++ b/src/lib/momento/validation.ex
@@ -12,7 +12,7 @@ defmodule Momento.Validation do
     validate_string(sorted_set_name, "sorted set name")
   end
 
-  @spec validate_sorted_set_elements(elements :: %{binary() => float()} | [{binary(), float()}]) ::
+  @spec validate_sorted_set_elements(elements :: %{binary() => number()} | [{binary(), number()}]) ::
           :ok | {:error, Momento.Error.t()}
   def validate_sorted_set_elements(nil),
     do: {:error, invalid_argument("Sorted set elements cannot be nil")}
@@ -20,7 +20,7 @@ defmodule Momento.Validation do
   def validate_sorted_set_elements(elements) do
     try do
       case Enum.all?(elements, fn {value, score} ->
-             is_binary(value) and is_float(score)
+             is_binary(value) and is_number(score)
            end) do
         true ->
           :ok
@@ -53,11 +53,11 @@ defmodule Momento.Validation do
   @spec validate_value(value :: binary()) :: :ok | {:error, Momento.Error.t()}
   def validate_value(value), do: validate_binary(value, "value")
 
-  @spec validate_score(score :: float()) :: :ok | {:error, Momento.Error.t()}
-  def validate_score(score), do: validate_float(score, "score")
+  @spec validate_score(score :: number()) :: :ok | {:error, Momento.Error.t()}
+  def validate_score(score), do: validate_number(score, "score")
 
-  @spec validate_ttl(ttl :: float()) :: :ok | {:error, Momento.Error.t()}
-  def validate_ttl(ttl), do: validate_positive_float(ttl, "TTL")
+  @spec validate_ttl(ttl :: number()) :: :ok | {:error, Momento.Error.t()}
+  def validate_ttl(ttl), do: validate_positive_number(ttl, "TTL")
 
   @spec validate_collection_ttl(collection_ttl :: Momento.Requests.CollectionTtl.t()) ::
           :ok | {:error, Momento.Error.t()}
@@ -68,7 +68,7 @@ defmodule Momento.Validation do
              "collection_ttl",
              Elixir.Momento.Requests.CollectionTtl
            ),
-         :ok <- validate_positive_float(collection_ttl.ttl_seconds, "TTL") do
+         :ok <- validate_positive_number(collection_ttl.ttl_seconds, "TTL") do
       :ok
     else
       error -> error
@@ -121,15 +121,15 @@ defmodule Momento.Validation do
   defp validate_binary(_, binary_name),
     do: {:error, invalid_argument("The #{binary_name} must be a binary")}
 
-  @spec validate_positive_float(float :: float(), float_name :: String.t()) ::
+  @spec validate_positive_number(num :: number(), name :: String.t()) ::
           :ok | {:error, Momento.Error.t()}
-  defp validate_positive_float(float, float_name) do
-    case validate_float(float, float_name) do
+  defp validate_positive_number(float, name) do
+    case validate_number(float, name) do
       :ok ->
         if float > 0.0 do
           :ok
         else
-          {:error, invalid_argument("The #{float_name} must be positive")}
+          {:error, invalid_argument("The #{name} must be positive")}
         end
 
       error ->
@@ -137,15 +137,15 @@ defmodule Momento.Validation do
     end
   end
 
-  @spec validate_float(float :: float(), float_name :: String.t()) ::
+  @spec validate_number(num :: number(), name :: String.t()) ::
           :ok | {:error, Momento.Error.t()}
-  defp validate_float(nil, float_name),
-    do: {:error, invalid_argument("The #{float_name} cannot be nil")}
+  defp validate_number(nil, name),
+    do: {:error, invalid_argument("The #{name} cannot be nil")}
 
-  defp validate_float(float, _) when is_float(float), do: :ok
+  defp validate_number(num, _) when is_number(num), do: :ok
 
-  defp validate_float(_, float_name),
-    do: {:error, invalid_argument("The #{float_name} must be a float")}
+  defp validate_number(_, name),
+    do: {:error, invalid_argument("The #{name} must be a number")}
 
   @spec validate_struct(struct :: struct(), struct_name :: String.t(), struct_type :: atom()) ::
           :ok | {:error, Momento.Error.t()}


### PR DESCRIPTION
This commit modifies the places where we were requiring floats as inputs to accept numbers instead. This mostly impacts TTLs, and just allows users to pass in an integer TTL if they prefer. Also allows users to pass in integers for sorted set scores, though we will still use floats for the outputs (response classes).