### PR TITLE
feat: use keyword list for cache client factory function

### DIFF
--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -17,11 +17,7 @@ defmodule Momento.IntegrationTestUtils do
     config = Configurations.Laptop.latest()
 
     cache_client =
-      CacheClient.create!(
-        config: config,
-        credential_provider: credential_provider,
-        default_ttl_seconds: 120
-      )
+      CacheClient.create!(config, credential_provider, 120)
 
     case CacheClient.create_cache(cache_client, cache_name) do
       {:ok, _} -> :ok

--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -15,7 +15,13 @@ defmodule Momento.IntegrationTestUtils do
     credential_provider = CredentialProvider.from_env_var!("TEST_AUTH_TOKEN")
 
     config = Configurations.Laptop.latest()
-    cache_client = CacheClient.create!(config: config, credential_provider: credential_provider, default_ttl_seconds: 120)
+
+    cache_client =
+      CacheClient.create!(
+        config: config,
+        credential_provider: credential_provider,
+        default_ttl_seconds: 120
+      )
 
     case CacheClient.create_cache(cache_client, cache_name) do
       {:ok, _} -> :ok

--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -16,8 +16,7 @@ defmodule Momento.IntegrationTestUtils do
 
     config = Configurations.Laptop.latest()
 
-    cache_client =
-      CacheClient.create!(config, credential_provider, 120)
+    cache_client = CacheClient.create!(config, credential_provider, 120)
 
     case CacheClient.create_cache(cache_client, cache_name) do
       {:ok, _} -> :ok

--- a/src/integration-test/momento/integration_test_utils.exs
+++ b/src/integration-test/momento/integration_test_utils.exs
@@ -15,7 +15,7 @@ defmodule Momento.IntegrationTestUtils do
     credential_provider = CredentialProvider.from_env_var!("TEST_AUTH_TOKEN")
 
     config = Configurations.Laptop.latest()
-    cache_client = CacheClient.create!(config, credential_provider, 120.0)
+    cache_client = CacheClient.create!(config: config, credential_provider: credential_provider, default_ttl_seconds: 120)
 
     case CacheClient.create_cache(cache_client, cache_name) do
       {:ok, _} -> :ok

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -49,17 +49,11 @@ defmodule Momento.CacheClient do
   - A {:ok, `%Momento.CacheClient{}`} tuple representing the connected client.
   """
   @spec create(
-          opts :: [
-            config: Configuration.t(),
-            credential_provider: CredentialProvider.t(),
-            default_ttl_seconds: number()
-          ]
+            config :: Configuration.t(),
+            credential_provider :: CredentialProvider.t(),
+            default_ttl_seconds :: number()
         ) :: {:ok, t()} | {:error, any()}
-  def create(opts) do
-    config = Keyword.get(opts, :config)
-    credential_provider = Keyword.get(opts, :credential_provider)
-    default_ttl_seconds = Keyword.get(opts, :default_ttl_seconds)
-
+  def create(config, credential_provider, default_ttl_seconds) do
     with {:ok, control_client} <- ScsControlClient.create(credential_provider),
          {:ok, data_client} <- ScsDataClient.create(credential_provider) do
       {:ok,
@@ -86,14 +80,12 @@ defmodule Momento.CacheClient do
   - A `%Momento.CacheClient{}` struct representing the connected client.
   """
   @spec create!(
-          opts :: [
-            config: Configuration.t(),
-            credential_provider: CredentialProvider.t(),
-            default_ttl_seconds: number()
-          ]
+            config :: Configuration.t(),
+            credential_provider :: CredentialProvider.t(),
+            default_ttl_seconds :: number()
         ) :: t()
-  def create!(opts) do
-    result = create(opts)
+  def create!(config, credential_provider, default_ttl_seconds) do
+    result = create(config, credential_provider, default_ttl_seconds)
 
     case result do
       {:ok, client} -> client

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -46,23 +46,58 @@ defmodule Momento.CacheClient do
 
   ## Returns
 
+  - A {:ok, `%Momento.CacheClient{}`} tuple representing the connected client.
+  """
+  @spec create(
+          opts :: [
+            config: Configuration.t(),
+            credential_provider: CredentialProvider.t(),
+            default_ttl_seconds: number()
+          ]
+        ) :: {:ok, t()} | {:error, any()}
+  def create(opts) do
+    config = Keyword.get(opts, :config)
+    credential_provider = Keyword.get(opts, :credential_provider)
+    default_ttl_seconds = Keyword.get(opts, :default_ttl_seconds)
+
+    with {:ok, control_client} <- ScsControlClient.create(credential_provider),
+         {:ok, data_client} <- ScsDataClient.create(credential_provider) do
+      {:ok,
+       %__MODULE__{
+         config: config,
+         credential_provider: credential_provider,
+         default_ttl_seconds: default_ttl_seconds,
+         control_client: control_client,
+         data_client: data_client
+       }}
+    end
+  end
+
+  @doc """
+  Creates a new CacheClient instance. Raises an exception if any errors occur during initialization.
+
+  ## Parameters
+
+  - `config`: A struct containing all tunable client settings.
+  - `credential_provider`: A struct representing the credentials to connect to the server.
+
+  ## Returns
+
   - A `%Momento.CacheClient{}` struct representing the connected client.
   """
   @spec create!(
-          config :: Configuration.t(),
-          credential_provider :: CredentialProvider.t(),
-          default_ttl_seconds :: number()
+          opts :: [
+            config: Configuration.t(),
+            credential_provider: CredentialProvider.t(),
+            default_ttl_seconds: number()
+          ]
         ) :: t()
-  def create!(config, credential_provider, default_ttl_seconds) do
-    with control_client <- ScsControlClient.create!(credential_provider),
-         data_client <- ScsDataClient.create!(credential_provider) do
-      %__MODULE__{
-        config: config,
-        credential_provider: credential_provider,
-        default_ttl_seconds: default_ttl_seconds,
-        control_client: control_client,
-        data_client: data_client
-      }
+  def create!(opts) do
+    result = create(opts)
+
+    case result do
+      {:ok, client} -> client
+      {:error, e} -> raise e
     end
   end
 

--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -49,9 +49,9 @@ defmodule Momento.CacheClient do
   - A {:ok, `%Momento.CacheClient{}`} tuple representing the connected client.
   """
   @spec create(
-            config :: Configuration.t(),
-            credential_provider :: CredentialProvider.t(),
-            default_ttl_seconds :: number()
+          config :: Configuration.t(),
+          credential_provider :: CredentialProvider.t(),
+          default_ttl_seconds :: number()
         ) :: {:ok, t()} | {:error, any()}
   def create(config, credential_provider, default_ttl_seconds) do
     with {:ok, control_client} <- ScsControlClient.create(credential_provider),
@@ -80,9 +80,9 @@ defmodule Momento.CacheClient do
   - A `%Momento.CacheClient{}` struct representing the connected client.
   """
   @spec create!(
-            config :: Configuration.t(),
-            credential_provider :: CredentialProvider.t(),
-            default_ttl_seconds :: number()
+          config :: Configuration.t(),
+          credential_provider :: CredentialProvider.t(),
+          default_ttl_seconds :: number()
         ) :: t()
   def create!(config, credential_provider, default_ttl_seconds) do
     result = create(config, credential_provider, default_ttl_seconds)

--- a/src/lib/momento/internal/scs_control_client.ex
+++ b/src/lib/momento/internal/scs_control_client.ex
@@ -18,20 +18,21 @@ defmodule Momento.Internal.ScsControlClient do
     end
   end
 
-  @spec create!(CredentialProvider.t()) :: t()
-  def create!(credential_provider) do
+  @spec create(CredentialProvider.t()) :: {:ok, t()} | {:error, any()}
+  def create(credential_provider) do
     control_endpoint = CredentialProvider.control_endpoint(credential_provider)
     tls_options = :tls_certificate_check.options(control_endpoint)
 
-    {:ok, channel} =
-      GRPC.Stub.connect(control_endpoint <> ":443",
-        cred: GRPC.Credential.new(ssl: tls_options)
-      )
-
-    %__MODULE__{
-      auth_token: CredentialProvider.auth_token(credential_provider),
-      channel: channel
-    }
+    with {:ok, channel} <-
+           GRPC.Stub.connect(control_endpoint <> ":443",
+             cred: GRPC.Credential.new(ssl: tls_options)
+           ) do
+      {:ok,
+       %__MODULE__{
+         auth_token: CredentialProvider.auth_token(credential_provider),
+         channel: channel
+       }}
+    end
   end
 
   @spec list_caches(client :: t()) :: Momento.Responses.ListCaches.t()

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -18,20 +18,21 @@ defmodule Momento.Internal.ScsDataClient do
     end
   end
 
-  @spec create!(CredentialProvider.t()) :: t()
-  def create!(credential_provider) do
+  @spec create(CredentialProvider.t()) :: {:ok, t()} | {:error, any()}
+  def create(credential_provider) do
     cache_endpoint = CredentialProvider.cache_endpoint(credential_provider)
     tls_options = :tls_certificate_check.options(cache_endpoint)
 
-    {:ok, channel} =
-      GRPC.Stub.connect(cache_endpoint <> ":443",
-        cred: GRPC.Credential.new(ssl: tls_options)
-      )
-
-    %__MODULE__{
-      auth_token: CredentialProvider.auth_token(credential_provider),
-      channel: channel
-    }
+    with {:ok, channel} <-
+           GRPC.Stub.connect(cache_endpoint <> ":443",
+             cred: GRPC.Credential.new(ssl: tls_options)
+           ) do
+      {:ok,
+       %__MODULE__{
+         auth_token: CredentialProvider.auth_token(credential_provider),
+         channel: channel
+       }}
+    end
   end
 
   @spec set(


### PR DESCRIPTION
This commit tweaks the cache client factory function to support a keyword list for its arguments. This allows callers to pass the arguments as named args, and change the order if they like. It also makes it a little more straightforward for us to provide default values for any of the options in the future.

Also adds a `create` variant in addition to our `create!`, so that users can opt in to pattern matching for errors if they prefer.