### PR TITLE
fix: patch vendored hdr histogram lib to support Mac ARM

### DIFF
--- a/vendor/hdr_histogram_erl/c_src/Makefile
+++ b/vendor/hdr_histogram_erl/c_src/Makefile
@@ -15,11 +15,18 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 # System type and C compiler/flags.
 
 UNAME_SYS := $(shell uname -s)
+UNAME_ARCH := $(shell uname -p)
+
+ARCH := x86_64
+ifeq ($(UNAME_ARCH), arm)
+	ARCH := arm64
+endif
+
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -arch $(ARCH) -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch $(ARCH) -finline-functions -Wall
+	LDFLAGS ?= -arch $(ARCH) -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= clang
 	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes


### PR DESCRIPTION
This commit patches our vendored copy of the HDR histogram library to allow it to build properly for Mac ARM processors.

In a subsequent commit we will add a load generator example that consumes this patched version of the library.