### PR TITLE
chore: Add docstrings to CacheClient

### DIFF
--- a/src/integration-test/momento/cache_client_test.exs
+++ b/src/integration-test/momento/cache_client_test.exs
@@ -2,7 +2,6 @@ Code.require_file("integration-test/momento/integration_test_utils.exs")
 
 defmodule CacheClientTest do
   use ExUnit.Case
-  doctest Momento.CacheClient
 
   alias Momento.CacheClient
 

--- a/src/lib/momento/internal/scs_control_client.ex
+++ b/src/lib/momento/internal/scs_control_client.ex
@@ -4,6 +4,8 @@ defmodule Momento.Internal.ScsControlClient do
   alias Momento.Auth.CredentialProvider
   alias Momento.Responses.{CacheInfo, CreateCache, DeleteCache, ListCaches}
 
+  @moduledoc false
+
   @enforce_keys [:auth_token, :channel]
   defstruct [:auth_token, :channel]
 

--- a/src/lib/momento/internal/scs_data_client.ex
+++ b/src/lib/momento/internal/scs_data_client.ex
@@ -7,6 +7,8 @@ defmodule Momento.Internal.ScsDataClient do
   @enforce_keys [:auth_token, :channel]
   defstruct [:auth_token, :channel]
 
+  @moduledoc false
+
   @opaque t() :: %__MODULE__{
             auth_token: String.t(),
             channel: GRPC.Channel.t()


### PR DESCRIPTION
Add docstrings for all the cache_client functions.

Exclude scs_control_client and scs_data_client from public-facing docs.