### PR TITLE
fix: Create release from src directory

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  Build and test:
     runs-on: ubuntu-20.04
     env:
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}

--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  Generate readme and prep release:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
@@ -27,6 +27,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          path: src
           release-type: elixir
           package-name: client-sdk-elixir
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'


### PR DESCRIPTION
Update release please to work from the src directory, so it can find mix.exs.

Make job names more clear.