### PR TITLE
fix: check the correct release-please outputs when releasing

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -34,14 +34,14 @@ jobs:
 
       - name: Publish test
         run: |
-          echo "Published version: ${{ steps.release.outputs.tag_name }}"
-        if: ${{ steps.release.outputs.release_created }}
+          echo "Published version: ${{ steps.release.outputs.src--tag_name }}"
+        if: ${{ steps.release.outputs.src--release_created }}
 
 #      - name: Publish to hex
-#        if: ${{ steps.release.outputs.release_created }}
 #        env:
 #          HEX_API_KEY: ${{ secrets.ELIXIR_HEX_PACKAGE_PUBLISH_API_KEY }}
 #        run: |
 #          pushd src
 #            mix hex.publish --yes
 #          popd
+#        if: ${{ steps.release.outputs.src--release_created }}

--- a/examples/doc_examples.exs
+++ b/examples/doc_examples.exs
@@ -414,12 +414,12 @@ Examples.DocExamples.example_API_CredentialProviderFromString()
 
 client = Examples.DocExamples.example_API_InstantiateCacheClient()
 
-Examples.DocExamples.example_API_ErrorHandlingHitMiss(client)
-Examples.DocExamples.example_API_ErrorHandlingSuccess(client)
-
 Examples.DocExamples.example_API_CreateCache(client)
 Examples.DocExamples.example_API_DeleteCache(client)
 Examples.DocExamples.example_API_CreateCache(client)
+
+Examples.DocExamples.example_API_ErrorHandlingHitMiss(client)
+Examples.DocExamples.example_API_ErrorHandlingSuccess(client)
 
 Examples.DocExamples.example_API_ListCaches(client)
 Examples.DocExamples.example_API_Set(client)


### PR DESCRIPTION
Prepend the path onto the release-please action outputs. When the path is specified in the release-please action, it adds it to all the outputs so projects at different paths can be differentiated.