### PR TITLE
chore: set the hex docs front page to the Momento.CacheClient module

### DIFF
--- a/src/lib/momento/cache_client.ex
+++ b/src/lib/momento/cache_client.ex
@@ -9,8 +9,26 @@ defmodule Momento.CacheClient do
 
   require Logger
 
-  @moduledoc """
+  @moduledoc ~S"""
   Client to perform operations against a Momento cache.
+
+  A client is created by supplying a configuration, a credential provider, and a default time-to-live:
+      config = %Momento.Config.Configuration{
+        transport_strategy: %Momento.Config.Transport.TransportStrategy{
+          grpc_config: %Momento.Config.Transport.GrpcConfiguration{
+            deadline_millis: 5000
+          }
+        }
+      }
+
+      credential_provider = Momento.Auth.CredentialProvider.from_env_var!("MOMENTO_AUTH_TOKEN")
+      default_ttl_seconds = 60.0
+      client = CacheClient.create!(config, credential_provider, default_ttl_seconds)
+
+  The resulting struct maintains the connection and can be given to any of the CacheClient functions to make calls to Momento:
+      iex> Momento.CacheClient.set(client, "cache", "key", "value")
+      {:ok, %Momento.Responses.Set.Ok{}}
+
   """
 
   @typedoc """

--- a/src/mix.exs
+++ b/src/mix.exs
@@ -13,7 +13,10 @@ defmodule Momento.MixProject do
       package: package(),
       name: "Momento Elixir SDK",
       source_url: "https://github.com/momentohq/client-sdk-elixir",
-      homepage_url: "https://www.gomomento.com/"
+      homepage_url: "https://www.gomomento.com/",
+      docs: [
+        main: "Momento.CacheClient"
+      ]
     ]
   end
 
@@ -47,7 +50,10 @@ defmodule Momento.MixProject do
     [
       files: ~w(lib generated .formatter.exs mix.exs ../README.md ../LICENSE),
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/momentohq/client-sdk-elixir"}
+      links: %{
+        "GitHub" => "https://github.com/momentohq/client-sdk-elixir",
+        "Momento Documentation" => "https://docs.momentohq.com/cache/develop/sdks/elixir"
+      }
     ]
   end
 end


### PR DESCRIPTION
Set the front page of the hex docs to Momento.CacheClient. It is the primary module users will be interacting with.

Fill out the top level doc of Momento.CacheClient.

Add a link to the Momento dev docs on the hex page for the sdk.